### PR TITLE
Cleanup and make consistent markdown files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,31 +4,31 @@
 
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
+our community a harassment-free experience for everyone, regardless of age,
+body size, disability, ethnicity, gender identity and expression, level of
+experience, nationality, personal appearance, race, religion, or sexual
+identity and orientation.
 
 ## Our Standards
 
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
+- The use of sexualized language or imagery and unwelcome sexual attention
+  or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
   address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Our Responsibilities
@@ -48,18 +48,19 @@ threatening, offensive, or harmful.
 This Code of Conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community. Examples of
 representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event. Representation of a
+project may be further defined and clarified by project maintainers.
 
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project team at dustin.deus@netzkern.de. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+complaints will be reviewed and investigated and will result in a response
+that is deemed necessary and appropriate to the circumstances. The project
+team is obligated to maintain confidentiality with regard to the reporter of
+an incident. Further details of specific enforcement policies may be posted
+separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
@@ -67,7 +68,8 @@ members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct/
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+<https://www.contributor-covenant.org/version/1/4/code-of-conduct/>
 
 [homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,20 +2,30 @@
 
 ## What?
 
-Individuals making significant and valuable contributions are given commit-access to the project to contribute as they see fit. This project is more like an open wiki than a standard guarded open source project.
+Individuals making significant and valuable contributions are given
+commit-access to the project to contribute as they see fit. This project is
+more like an open wiki than a standard guarded open source project.
 
 ## Rules
 
 There are a few basic ground-rules for contributors:
 
-1. **No `--force` pushes** on `master` or modifying the Git history in any way after a PR has been merged.
-1. **Non-master branches** ought to be used for ongoing work.
-1. **External API changes and significant modifications** ought to be subject to an **internal pull-request** to solicit feedback from other contributors.
-1. Internal pull-requests to solicit feedback are *encouraged* for any other non-trivial contribution but left to the discretion of the contributor.
-1. Contributors should attempt to adhere to the prevailing code-style.
-1. At least two contributors, or one core member, must approve pull-requests prior to merging.
-1. All integrated CI services must be green, unless an agreement has been reached in the conversation about the exception, before a pull-request can be merged.
-1. Breaking changes or significant new features must be merged by a core member. Small pull-requests, e.g. documentation typo corrections, may be merged by any member with commit access.
+1. **No `--force` pushes** on `master` or modifying the Git history in any way
+   after a PR has been merged.
+2. **Non-master branches** ought to be used for ongoing work.
+3. **External API changes and significant modifications** ought to be subject
+   to an **internal pull-request** to solicit feedback from other contributors.
+4. Internal pull-requests to solicit feedback are _encouraged_ for any other
+   non-trivial contribution but left to the discretion of the contributor.
+5. Contributors should attempt to adhere to the prevailing code-style.
+6. At least two contributors, or one core member, must approve pull-requests
+   prior to merging.
+7. All integrated CI services must be green, unless an agreement has been
+   reached in the conversation about the exception, before a pull-request can
+   be merged.
+8. Breaking changes or significant new features must be merged by a core
+   member. Small pull-requests, e.g. documentation typo corrections, may be
+   merged by any member with commit access.
 
 ## Releases
 
@@ -23,33 +33,30 @@ Declaring formal releases remains the prerogative of the project maintainers.
 
 ## Changes to this arrangement
 
-This is an experiment and feedback is welcome! This document may also be subject to pull-requests or changes by contributors where you believe you have something valuable to add or change.
+This is an experiment and feedback is welcome! This document may also be
+subject to pull-requests or changes by contributors where you believe you have
+something valuable to add or change.
 
------------------------------------------
+--------------------------------------------------------------------------------
 
-<a id="developers-certificate-of-origin"></a>
+[]()
+
 ## Developer's Certificate of Origin 1.1
 
 By making a contribution to this project, I certify that:
 
-* (a) The contribution was created in whole or in part by me and I
-  have the right to submit it under the open source license
-  indicated in the file; or
-
-* (b) The contribution is based upon previous work that, to the best
-  of my knowledge, is covered under an appropriate open source
-  license and I have the right under that license to submit that
-  work with modifications, whether created in whole or in part
-  by me, under the same open source license (unless I am
-  permitted to submit under a different license), as indicated
-  in the file; or
-
-* (c) The contribution was provided directly to me by some other
-  person who certified (a), (b) or (c) and I have not modified
-  it.
-
-* (d) I understand and agree that this project and the contribution
-  are public and that a record of the contribution (including all
-  personal information I submit with it, including my sign-off) is
-  maintained indefinitely and may be redistributed consistent with
-  this project or the open source license(s) involved.
+- (a) The contribution was created in whole or in part by me and I have the
+  right to submit it under the open source license indicated in the file; or
+- (b) The contribution is based upon previous work that, to the best of my
+  knowledge, is covered under an appropriate open source license and I have
+  the right under that license to submit that work with modifications, whether
+  created in whole or in part by me, under the same open source license
+  (unless I am permitted to submit under a different license), as indicated in
+  the file; or
+- (c) The contribution was provided directly to me by some other person who
+  certified (a), (b) or (c) and I have not modified it.
+- (d) I understand and agree that this project and the contribution are public
+  and that a record of the contribution (including all personal information I
+  submit with it, including my sign-off) is maintained indefinitely and may be
+  redistributed consistent with this project or the open source license(s)
+  involved.

--- a/DEV.md
+++ b/DEV.md
@@ -1,26 +1,27 @@
 # Development
 
 ## Installation
-```
-$ go get ./...
+
+```shell
+go get ./...
 ```
 
 ## Build Binaries
 
-```
-$ go get github.com/goreleaser/goreleaser
-$ goreleaser
+```shell
+go get github.com/goreleaser/goreleaser
+goreleaser
 ```
 
 ## Publish
 
-```
-$ git tag -a v0.1.0 -m "First release"
-$ git push origin v0.1.0
+```shell
+git tag -a v0.1.0 -m "First release"
+git push origin v0.1.0
 ```
 
 ## Snapshots
 
-```
-$ goreleaser --snapshot --skip-validate
+```shell
+goreleaser --snapshot --skip-validate
 ```

--- a/README.md
+++ b/README.md
@@ -1,68 +1,79 @@
-<p align="center">
-<img src="/logo.png" alt="butler" style="max-width:100%;">
-</p>
+![butler](/logo.png)
 
-Butler is an automatation tool to scaffold new projects in only a few seconds. We provide a powerful interactive cli.
-When you create a project template you can create a [`Survey`](/docs/templateSurveys.md). Surveys are used to collect informations from the users to generate individual templates. Beside templating we also plan to integrate common tasks of popular Project Managents Tools like Jira, Confluence in Butler.
+Butler is an automatation tool to scaffold new projects in only a few seconds.
+We provide a powerful interactive cli. When you create a project template you
+can create a [`Survey`](/docs/templateSurveys.md). Surveys are used to collect
+informations from the users to generate individual templates. Beside
+templating we also plan to integrate common tasks of popular Project Managents
+Tools like Jira, Confluence in Butler.
 
 > Bootstraping projects should be fun!
 
-## Features
+# Features
+
 - Template Surveys
 - Conditional files and folders
 - After hooks for post-processing
 - Auto Update
 - Distributed configs
 
-## Principles
+# Principles
+
 - Project Templates are simple git repositories
-- Everything is a template you don't have to deal with `/template` directories or `.tmpl` files
+- Everything is a template you don't have to deal with `/template` directories
+  or `.tmpl` files
 - Required informations are asked during the bootstrapping process
 
-## Usage
+# Usage
 
 1. [Download here](https://github.com/netzkern/butler/releases)
 2. Install in `PATH`
 3. Run `butler`
 
-## Documentation
+# Documentation
 
-* <a href="/docs/config.md"><code><b>Config</b></code></a>
-* <a href="/docs/templateSurveys.md"><code><b>Template Surveys</b></code></a>
-* <a href="/docs/templateSyntax.md"><code><b>Template Syntax</b></code></a>
-* <a href="/docs/gitHooks.md"><code><b>Git Hooks</b></code></a>
-* <a href="/docs/debugging.md"><code><b>Debugging</b></code></a>
-* <a href="#commands"><code><b>Commands</b></code></a>
+- [`**Config**`](/docs/config.md)
+- [`**Template Surveys**`](/docs/templateSurveys.md)
+- [`**Template Syntax**`](/docs/templateSyntax.md)
+- [`**Git Hooks**`](/docs/gitHooks.md)
+- [`**Debugging**`](/docs/debugging.md)
+- [`**Commands**`](#commands)
 
-## Commands
+# Commands
 
-- **Project Templates:** This command will create a new project based on the selected template.
+- **Project Templates:** This command will create a new project based on the
+  selected template.
 - **Install Git Hooks:** This command will install all selected hooks.
 - **Auto Update:** This command will update Butler to the latest version.
 - **Report a bug:** This command will open a new Github issue.
 - **Version:** This command will return the current version of Butler.
 
-### Maintenance across teams
+## Maintenance across teams
 
 - Butler is able to update itself. The latest Github release is used.
-- Stay up-to-date with new templates without to update your config manually just set the environment variable `BUTLER_CONFIG_URL` to [butler.yml on master](https://raw.githubusercontent.com/netzkern/butler/master/butler.yml) and both configs are merged.
+- Stay up-to-date with new templates without to update your config manually
+  just set the environment variable `BUTLER_CONFIG_URL` to
+  [butler.yml on master](https://raw.githubusercontent.com/netzkern/butler/master/butler.yml)
+  and both configs are merged.
 
-### What Butler template looks like ?
+## What Butler template looks like?
 
 [example-project-template](https://github.com/netzkern/example-project-template)
 
-### Lead Maintainers
+## Lead Maintainers
 
-* [__Dustin Deus__](https://github.com/StarpTech), <https://twitter.com/dustindeus>, <https://www.npmjs.com/~starptech>
+- [**Dustin Deus**](https://github.com/StarpTech), <https://twitter.com/dustindeus>, <https://www.npmjs.com/~starptech>
 
-## Acknowledgements
+# Acknowledgements
 
 This project is kindly sponsored by [netzkern](http://netzkern.de). We're [hiring!](http://karriere.netzkern.de/)
 
-## License
+# License
 
 Licensed under [MIT](./LICENSE).
 
-### Credits
+## Credits
 
-<div>Icons made by <a href="http://www.freepik.com" title="Freepik">Freepik</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a> is licensed by <a href="http://creativecommons.org/licenses/by/3.0/" title="Creative Commons BY 3.0" target="_blank">CC 3.0 BY</a></div>
+Icons made by [Freepikcom](http://www.freepik.com Freepik)
+from [www.flaticon.com](https://www.flaticon.com/ Flaticon)
+is licensed by [CC 3.0 BY](http://creativecommons.org/licenses/by/3.0/ Creative Commons BY 3.0)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Tools like Jira, Confluence in Butler.
 
 > Bootstraping projects should be fun!
 
-# Features
+## Features
 
 - Template Surveys
 - Conditional files and folders
@@ -19,20 +19,20 @@ Tools like Jira, Confluence in Butler.
 - Auto Update
 - Distributed configs
 
-# Principles
+## Principles
 
 - Project Templates are simple git repositories
 - Everything is a template you don't have to deal with `/template` directories
   or `.tmpl` files
 - Required informations are asked during the bootstrapping process
 
-# Usage
+## Usage
 
 1. [Download here](https://github.com/netzkern/butler/releases)
 2. Install in `PATH`
 3. Run `butler`
 
-# Documentation
+## Documentation
 
 - [`**Config**`](/docs/config.md)
 - [`**Template Surveys**`](/docs/templateSurveys.md)
@@ -41,7 +41,7 @@ Tools like Jira, Confluence in Butler.
 - [`**Debugging**`](/docs/debugging.md)
 - [`**Commands**`](#commands)
 
-# Commands
+## Commands
 
 - **Project Templates:** This command will create a new project based on the
   selected template.
@@ -66,11 +66,11 @@ Tools like Jira, Confluence in Butler.
 
 - [**Dustin Deus**](https://github.com/StarpTech), <https://twitter.com/dustindeus>, <https://www.npmjs.com/~starptech>
 
-# Acknowledgements
+## Acknowledgements
 
 This project is kindly sponsored by [netzkern](http://netzkern.de). We're [hiring!](http://karriere.netzkern.de/)
 
-# License
+## License
 
 Licensed under [MIT](./LICENSE).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-![butler](/logo.png)
+<p align="center">
+<img src="/logo.png" alt="butler" style="max-width:100%;">
+</p>
 
 Butler is an automatation tool to scaffold new projects in only a few seconds.
 We provide a powerful interactive cli. When you create a project template you
@@ -74,6 +76,6 @@ Licensed under [MIT](./LICENSE).
 
 ## Credits
 
-Icons made by [Freepikcom](http://www.freepik.com Freepik)
-from [www.flaticon.com](https://www.flaticon.com/ Flaticon)
-is licensed by [CC 3.0 BY](http://creativecommons.org/licenses/by/3.0/ Creative Commons BY 3.0)
+Icons made by [Freepikcom](http://www.freepik.com "Freepik")
+from [www.flaticon.com](https://www.flaticon.com/ "Flaticon")
+is licensed by [CC 3.0 BY](http://creativecommons.org/licenses/by/3.0/ "Creative Commons BY 3.0")

--- a/docs/config.md
+++ b/docs/config.md
@@ -3,6 +3,7 @@
 In the config you can define which project templates are accessible for the user.
 
 ## The butler.yml file
+
 ```yml
 templates:
   - name:   The template name (string, required)
@@ -12,8 +13,13 @@ variables:
   test:     The value for custom variable
 ```
 
-#### Custom variables
-You can define custom variables to use them inside project templates. Custom template variables have priority over local variables.
+### Custom variables
+
+You can define custom variables to use them inside project templates. Custom
+template variables have priority over local variables.
 
 ### Distribute config
-You can set the environment variable `BUTLER_CONFIG_URL` to any url to load your config from an external storage. This make it easy to distribute template updates across a company. You local configuration is merged.
+
+You can set the environment variable `BUTLER_CONFIG_URL` to any url to load
+your config from an external storage. This make it easy to distribute template
+updates across a company. You local configuration is merged.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -2,6 +2,6 @@
 
 Enable different log level (debug, info, warn, error):
 
-```
-$ butler --logLevel=info ui
+```shell
+butler --logLevel=info ui
 ```

--- a/docs/gitHooks.md
+++ b/docs/gitHooks.md
@@ -1,6 +1,9 @@
 # Butler Git Hooks
 
-You don't need any tooling to create hooks. We have agreed on a simple convention. Your project is shipped with a `git_hooks` folder which has the same directory structure like the git `hooks` folder. In this way we can create symbol links and make them versionable with git.
+You don't need any tooling to create hooks. We have agreed on a simple
+convention. Your project is shipped with a `git_hooks` folder which has the
+same directory structure like the git `hooks` folder. In this way we can
+create symbol links and make them versionable with git.
 
 If you create a new git hook file you have to excute the command again.
 
@@ -11,7 +14,8 @@ If you create a new git hook file you have to excute the command again.
 3. Run Butler and run `Install Git Hooks`
 
 **pre-commit**
-```sh
+
+```shell
 #!/bin/sh
 
 echo "hook executed!"
@@ -22,35 +26,38 @@ _Git Hooks are installed automatically when a new project template is created._
 ## Run hooks in different languages
 
 Node.js
-```sh
+
+```shell
 #!/usr/bin/env node
 
 console.log("hook executed!")
 ```
 
 Python
-```py
+
+```python
 #!/usr/bin/python
 
 print "hook executed!"
 ```
 
 Powershell
-```ps
+
+```powershell
 powershell -ExecutionPolicy RemoteSigned -Command .\.git_hooks\scripts\build.ps1
 ```
 
 ## Details
+
 Hooks are programs you can place in the `$GIT_DIR/git_hooks` directory to
 trigger actions at certain points in git's execution.
- 
-Before Git invokes a hook, it changes its working directory to either
-the root of the working tree in a non-bare repository, or to the
-$GIT_DIR in a bare repository.
- 
-Hooks can get their arguments via the environment, command-line
-arguments, and stdin. See the documentation for each hook below for
-details.
- 
-The currently supported hooks are described [here](https://git-scm.com/docs/githooks).
 
+Before Git invokes a hook, it changes its working directory to either the root
+of the working tree in a non-bare repository, or to the $GIT_DIR in a bare
+repository.
+
+Hooks can get their arguments via the environment, command-line arguments, and
+stdin. See the documentation for each hook below for details.
+
+The currently supported hooks are described
+[here](https://git-scm.com/docs/githooks).

--- a/docs/templateSurveys.md
+++ b/docs/templateSurveys.md
@@ -1,17 +1,20 @@
 # Butler Template Surveys
 
-Your are able to create an interactive survey before your template is proceed. The results can be used to build templates for user-specific requirements.
+Your are able to create an interactive survey before your template is proceed.
+The results can be used to build templates for user-specific requirements.
 
 ## How to create a survey?
 
-1. Create a config file `butler-survey.yml` in the root directory of your template repository.
+1. Create a config file `butler-survey.yml` in the root directory of your
+   template repository.
 2. Create questions based on the [format](#configuration) below.
-3. Build your template with the [easy to use](/docs/templateSyntax.md#get-survey-results) template syntax.
+3. Build your template with the [easy to use](/docs/templateSyntax.md#get-survey-results)
+   template syntax.
 4. Run butler and create a new project.
 
 ## The butler-survey.yml file
 
-```
+```plain
 deprecated:     Whether or not this template is deprecated (optional, boolean)
 butlerVersion:  The required butler version (optional, semver range string e.g "1.0.x" or ">1.0.0 <2.0.0 || >=3.0.0")
 
@@ -23,7 +26,7 @@ questions:
     default:  The default value ([]string for select otherwise string)
     help:     The help message (string, optional)
     required: Whether or not this question is required (boolean)
-    
+
 afterHooks:
   - cmd:      The command to execute (string, required)
     args:     The arguments for the cmd ([]string, optional)
@@ -33,9 +36,12 @@ variables:
   test:       The value for custom variable
 ```
 
-#### After hooks
-Hooks are executed after the project is created. The hook pipeline is aborted when any command return an error.
+### After hooks
 
+Hooks are executed after the project is created. The hook pipeline is aborted
+when any command return an error.
 
-#### Custom variables
-You can define custom variables. In case of a conflict the template variables have priority over local variables.
+### Custom variables
+
+You can define custom variables. In case of a conflict the template variables
+have priority over local variables.

--- a/docs/templateSyntax.md
+++ b/docs/templateSyntax.md
@@ -1,20 +1,27 @@
 # Butler Template Syntax
 
-We use the template engine from Go. [Here](https://golang.org/pkg/text/template/) you can find an overview about all template features. We use a unique delimiter to avoid collsion with existing template engines.
+We use the template engine from Go. [Here](https://golang.org/pkg/text/template/)
+you can find an overview about all template features. We use a unique
+delimiter to avoid collsion with existing template engines.
 
 ## Delimiter
 
 Inside files you have to use:
-```
-butler{<expr>} 
-```
-For directory or file names you have to use a different delimiter to save character because windows has a path [limit](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx). We recommend to use short question names in the `survey-butler.yml`.
-```
-{<expr>} 
+
+```shell
+butler{<expr>}
 ```
 
+For directory or file names you have to use a different delimiter to save
+character because windows has a path [limit](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx).
+We recommend to use short question names in the `survey-butler.yml`.
+
+```yaml
+{<expr>}
+```
 
 ## Where can I use templates?
+
 - Filenames
 - Directories
 - Text files (.html, .md, .txt, .cshtml, .cs, .js ...)
@@ -24,60 +31,77 @@ _Butler maintain a [list](https://github.com/netzkern/butler/blob/master/command
 # Built in
 
 ## Project details
+
 - `butler{ .Project.Name }` Return the project name
 - `butler{ .Project.Description }` Return the project description
 - `butler{ .Date }` Return the date (RFC3339)
 - `butler{ .Year }` Return the year (4-digits)
 
 ## Access to custom variables
-Custom variables can be defined in the local `butler.yml` file or in the template `butler-survey.yml` file.
+
+Custom variables can be defined in the local `butler.yml` file or in the
+template `butler-survey.yml` file.
 
 ```
 butler{ .Vars.company }
 ```
 
 ## Helper functions
+
 - `butler{ toCamelCase .Project.Name }` Transform a string to camel-case.
 - `butler{ toPascalCase "foo-bar" }` Transform a string to pascal-case.
 - `butler{ toSnakeCase "foo-bar" }` Transform a string to snake-case.
 - `butler{ toPascalCase "foo-bar" }` Transform a string to pascal-case.
-- `butler{ join $array "," }` Joins all elements of an array into a string and returns this string.
+- `butler{ join $array "," }` Joins all elements of an array into a string and
+   returns this string.
 - `butler{ uuid }` Returns a random UUID Version 4 string.
 
 _All functions are written in camelCase_
 
 ## Define variables in templates
-```
+
+```go
 butler{$id := uuid} // generate id
 butler{$id} // print id
 ```
 
 ## Get survey results
-We generate getter functions to provide an easier access to survey results. If you have a question with the name `color` the result is accessible by:
 
-```
+We generate getter functions to provide an easier access to survey results. If
+you have a question with the name `color` the result is accessible by:
+
+```go
 butler{ getColor }
 ```
 
 ## Get survey question
+
 You can access the survey questions with the same approach
-```
+
+```go
 butler{ getColorQuestion }
 ```
 
 ## Conditions in templates
-```
+
+```go
 butler{if eq getDb "mongodb"}
 // your template
 butler{end}
 ```
 
 ## Conditional directories and files
-Based on the survey you can decide which directories or files should be included or removed. The following example will include the folder when the question about the `database` will be answered with `mongodb`.
-```
+
+Based on the survey you can decide which directories or files should be
+included or removed. The following example will include the folder when the
+question about the `database` will be answered with `mongodb`.
+
+```go
 Folder: {if eq getDb `mongodb` }mongodb{end}
 ```
+
 Build the filename based on an answer:
-```
+
+```go
 Filename: {print getColor `.md`}
 ```


### PR DESCRIPTION
- files had a different line length
- shell commands had leading `$` prompt
- add fenced code block language markers
- use native markup where some HTML was embedded
- fixup whitespace inline with community practice

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netzkern/butler/4)
<!-- Reviewable:end -->
